### PR TITLE
식재료 가격 상승, 하락 api 응답 변경 작업(#18)

### DIFF
--- a/src/components/common/IconBox.tsx
+++ b/src/components/common/IconBox.tsx
@@ -40,9 +40,9 @@ function IconBox({ img, text, percent }: IconBoxProps) {
           <img src={img} style={{ width: '55px', height: '55px' }} />
           {percent &&
             (percent > 0 ? (
-              <PercentAscArea>{`${percent.toFixed(2)}%`}</PercentAscArea>
+              <PercentAscArea>{`${percent}%`}</PercentAscArea>
             ) : (
-              <PercentDescArea>{`${percent.toFixed(2)}%`}</PercentDescArea>
+              <PercentDescArea>{`${percent}%`}</PercentDescArea>
             ))}
         </Paper>
       </Box>

--- a/src/pages/ingredients/Ingredients.tsx
+++ b/src/pages/ingredients/Ingredients.tsx
@@ -157,7 +157,7 @@ function Ingredients() {
               <IconBox
                 img={rankInfo.ingredient_image || no_image}
                 text={rankInfo.ingredient_name}
-                percent={((rankInfo.curr_price - rankInfo.prev_price) / rankInfo.prev_price) * 100}
+                percent={rankInfo.percent}
               />
             </div>
           ))}
@@ -171,7 +171,7 @@ function Ingredients() {
               <IconBox
                 img={rankInfo.ingredient_image || no_image}
                 text={rankInfo.ingredient_name}
-                percent={((rankInfo.curr_price - rankInfo.prev_price) / rankInfo.prev_price) * 100}
+                percent={rankInfo.percent}
               />
             </div>
           ))}

--- a/src/services/ingredient/getAsc.ts
+++ b/src/services/ingredient/getAsc.ts
@@ -9,8 +9,7 @@ type RankAscInfoProps = {
   ingredient_id: number;
   ingredient_name: string;
   ingredient_image: string;
-  prev_price: number;
-  curr_price: number;
+  percent: number;
 };
 
 type ResponseProps = {

--- a/src/services/ingredient/getDesc.ts
+++ b/src/services/ingredient/getDesc.ts
@@ -9,8 +9,7 @@ type RankDescInfoProps = {
   ingredient_id: number;
   ingredient_name: string;
   ingredient_image: string;
-  prev_price: number;
-  curr_price: number;
+  percent: number;
 };
 
 type ResponseProps = {


### PR DESCRIPTION
## 📑 개요

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->
#18 식재료 가격 상승, 하락 api 응답 변경


### ✅ PR 체크리스트

---

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

### 🚀 상세 작업 내용

---
- [x] 식재료 가격 상승 api 응답 가격에서 퍼센트로 변경
- [x] 식재료 가격 하락 api 응답 가격에서 퍼센트로 변경

